### PR TITLE
refactor: 金利抽出の精度向上とDecimal切り捨て処理実装

### DIFF
--- a/tests/unit/test_aoimori_shinkin_extractors.py
+++ b/tests/unit/test_aoimori_shinkin_extractors.py
@@ -1,0 +1,45 @@
+import pytest
+from decimal import Decimal
+from loanpedia_scraper.scrapers.aoimori_shinkin.extractors import (
+    zenkaku_to_hankaku,
+    clean_rate_cell,
+)
+
+
+# ------------------------------
+# zenkaku_to_hankaku のテスト
+# ------------------------------
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (None, ""),
+        ("", ""),
+        ("ＡＢＣ　１２３", "ABC 123"),  # 全角数字と全角スペース
+        (" 改行\nタブ\t混在 ", "改行 タブ 混在"),  # 空白・改行・タブをまとめる
+    ],
+)
+def test_zenkaku_to_hankaku(input, expected):
+    assert zenkaku_to_hankaku(input) == expected
+
+
+# ------------------------------
+# clean_rate_cell のテスト
+# ------------------------------
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("２．５％", Decimal("2.50")),  # 全角混じり → 半角化
+        ("年2.1099％", Decimal("2.10")),  # 小数第2位まで切り捨て
+        ("1,200%", Decimal("1200.00")),  # カンマ桁区切り
+        ("1.200%", Decimal("1.20")),  # 小数点として解釈
+        ("金利なし", None),  # 数値なし
+        (None, None),  # None入力
+    ],
+)
+def test_clean_rate_cell(input, expected):
+    out = clean_rate_cell(input)
+    if expected is None:
+        assert out is None
+    else:
+        assert isinstance(out, Decimal)
+        assert out == expected


### PR DESCRIPTION
- zenkaku_to_hankaku関数のリファクタリングと最適化
- clean_rate_cell関数をDecimalベースに変更し小数第2位切り捨て対応
- 数値抽出パターンの改善で桁区切りカンマ対応
- 単体テストの追加でエッジケースをカバー

🤖 Generated with [Claude Code](https://claude.ai/code)